### PR TITLE
fix wrench duplication

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -21,6 +21,7 @@ read_globals = {
 	"doc",
 	"intllib",
 	"fakelib",
+	"wrench"
 }
 
 files = {


### PR DESCRIPTION
Clears the `data` field on the to-be-placed "wrenched" items

CC @SwissalpS 