### PR TITLE
Exclude more nodes from being dug by digtron and handle preserve_metadata

### DIFF
--- a/util.lua
+++ b/util.lua
@@ -68,6 +68,7 @@ digtron.mark_diggable = function(pos, nodes_dug, player)
 			string.format("Digtron encountered unknown node %s at (%d, %d, %d), not digging", target.name, pos.x, pos.y, pos.z))
 	elseif (targetdef.diggable or targetdef.buildable_to) and
 		(targetdef.can_dig == nil or targetdef.can_dig(pos, player)) and
+		targetdef.on_dig == minetest.nodedef_default.on_dig and
 		target.name ~= "air" then
 		nodes_dug:set(pos.x, pos.y, pos.z, true)
 		local in_known_group = false


### PR DESCRIPTION
Fixes #75

This includes 5 changes:

 - unknown nodes are not dug, because there is potential for destroying important information in node metadata
 - nodes with both `diggable = false` and `buildable_to = false` are not dug
 - nodes with `preserve_metadata` are correctly handled 
 - nodes that have a non default `on_dig` callback are not dug
 - `air` nodes are not dug

**Using the `Hide Whitespace` option when reviewing in the github interface is recommended**

### Issues to discuss before merging

 - digging unknown nodes may be desirable when administratively cleaning up a dirty game/mod update, so perhaps there should be a digtron setting to enable/disable unknown node digging?
 - ~~AFAICT the engine provides no good way to detect non default `on_dig`; the one implemented here will probably break in the presence of node callback instrumentation like the mod profiler does~~ _now using `minetest.nodedef_default` which is already used in the placement code and should actually - after checking the mod profiler code - work just fine; the only downside being that nodedef_default is not officially documented_
 - ~~it seems that handling the `preserve_metadata` case would be easy, so perhaps that should be added instead~~ calling `preserve_metadata` has been implemented, but this may create an item with loads of metadata, in edge cases possibly breaking the game when put into the digtron inventory
 - `air` nodes were already handled specially before (skipping cost and drop calculations), but they were still added to the `nodes_dug` set; I can't see a good reason for that and it should not make much difference in practice and making them fully undiggable reduces one nesting level, but it may still be undesirable to change that in this PR
 - decide that the changed door digging behavior described in the testing section below is acceptable (especially test case 4)

### Testing

1. place some sand above a wooden door and a digtron digger to dig only the upper half: before this PR the sand will drop, because the hidden door node is dug; after this PR the hidden door node isn't dug and blocks digtron movement
2. same scenario, but digging only the lower half: both before and after this PR the door gets dug and both halves are removed (the upper half by `on_destruct`) 
3. same scenario, but trying to dig both halves on the side: both before and after this PR the door gets dug and both halves are removed (but after this PR the upper half isn't dug by digtron, but removed by `on_destruct`)
4. same scenario, but trying to dig both halves in the forward direction: before this PR both halves were dug and the digtron could move forward; after this PR the movement is blocked and nothing is dug
5. place a basket from the basket mod and a digtron digger to dig it: before this PR the basket was dug, producing a broken item (without the basket content) that crashes the server when placing it; after this PR the basket is ~~not~~ dug, ~~blocking digtron movement~~ producing a working basket item with all it's contents intact
6. place a butterfly in day light and a digtron digger to dig it: both before and after this PR the butterfly gets dug
7. same as above, but at night, wait until the butterflies become invisible before trying to dig: before this PR the invisible butterfly nodes were dug; after this PR the invisible butterfly nodes are not dug (blocking digtron movement) and become visible again in day light 
8. somehow produce an unknown node and set a digger to it: before this PR the unknown node was dug; after this PR the unknown node is not dug, blocking digtron movement
9. digging stone, water etc. is not changed by this PR

This is mostly an improvement, but 4 feels like a regression. I think it is actually correct to not dig the invisible door node, but it sucks that this prevents digging through a door. Unfortunately I see no way to detect that the door's `on_destruct` would remove the hidden node and therefore enable movement into the space occupied by the door. The `on_destruct` can't be called earlier than the `set_node` when executing the move, because otherwise falling nodes above the door would start to fall into the lower half.

Test case 5 exposes a Matryoshka doll scenario, but IMO it is still the right thing to do. The correct fix is probably to drop items which exceed some threshold for the length of their serialized metadata on the ground instead of adding them to the digtron storage. Like this:
```diff
diff --git a/util.lua b/util.lua
index 6942c99..e51c62e 100644
--- a/util.lua
+++ b/util.lua
@@ -155,7 +155,8 @@ end
 digtron.place_in_inventory = function(itemname, inventory_positions, fallback_pos)
 	--tries placing the item in each inventory node in turn. If there's no room, drop it at fallback_pos
 	local itemstack = ItemStack(itemname)
-	if inventory_positions ~= nil then
+	local size = string.len(minetest.serialize(itemstack:get_meta():to_table()))
+	if size < 1024 and inventory_positions ~= nil then
 		for _, location in pairs(inventory_positions) do
 			node_inventory_table.pos = location.pos
 			local inv = minetest.get_inventory(node_inventory_table)
```
 
The change in behavior in test case 7 is IMO a bug in MTG just exposed by this change (it is caused by the invisible butterfly nodes not having `buildable_to = true` unlike the visible ones)