### PR TITLE
Always provide the vector metatable to node callbacks

### DIFF
--- a/class_layout.lua
+++ b/class_layout.lua
@@ -5,7 +5,7 @@ digtron.DigtronLayout.__index = digtron.DigtronLayout
 -- Creation
 
 local get_node_image = function(pos, node)
-	local node_image = {node=node, pos={x=pos.x, y=pos.y, z=pos.z}}
+	local node_image = {node=node, pos=vector.copy(pos)}
 	local node_def = digtron.get_nodedef(node.name)
 	node_image.paramtype2 = node_def.paramtype2
 	local meta = minetest.get_meta(pos)
@@ -59,7 +59,7 @@ function digtron.DigtronLayout.create(pos, player)
 	self.old_pos_pointset = digtron.Pointset.create() -- For tracking original location of nodes if we do transformations on the Digtron
 	self.nodes_dug = digtron.Pointset.create() -- For tracking adjacent nodes that will have been dug by digger heads in future
 	self.contains_protected_node = false -- used to indicate if at least one node in this digtron array is protected from the player.
-	self.controller = {x=pos.x, y=pos.y, z=pos.z} 	--Make a deep copy of the pos parameter just in case the calling code wants to play silly buggers with it
+	self.controller = vector.copy(pos) 	--Make a deep copy of the pos parameter just in case the calling code wants to play silly buggers with it
 
 	-- We never visit the source node, so insert it into the all table a priori.
 	-- Revisit this design decision if a controller node is created that contains fuel or inventory or whatever.
@@ -397,7 +397,7 @@ local node_callbacks = function(player)
 
 			for _, callback in ipairs(minetest.registered_on_dignodes) do
 				-- Copy pos and node because callback can modify them
-				local pos_copy = {x=old_pos.x, y=old_pos.y, z=old_pos.z}
+				local pos_copy = vector.copy(old_pos)
 				local oldnode_copy = {name=old_node.name, param1=old_node.param1, param2=old_node.param2}
 				callback(pos_copy, oldnode_copy, digtron.fake_player)
 			end
@@ -417,7 +417,7 @@ local node_callbacks = function(player)
 
 			for _, callback in ipairs(minetest.registered_on_placenodes) do
 				-- Copy pos and node because callback can modify them
-				local pos_copy = {x=new_pos.x, y=new_pos.y, z=new_pos.z}
+				local pos_copy = vector.copy(new_pos)
 				local oldnode_copy = {name=old_node.name, param1=old_node.param1, param2=old_node.param2}
 				local newnode_copy = {name=new_node.name, param1=new_node.param1, param2=new_node.param2}
 				callback(pos_copy, newnode_copy, digtron.fake_player, oldnode_copy)

--- a/init.lua
+++ b/init.lua
@@ -6,6 +6,23 @@ digtron.auto_controller_colorize = "#88000030"
 digtron.pusher_controller_colorize = "#00880030"
 digtron.soft_digger_colorize = "#88880030"
 
+if not vector.copy then
+	error("[digtron] Your Luanti/Minetest version is too old. Please update to 5.5.0 or newer.")
+end
+
+digtron.set_inventory_action_loggers = function(def, name)
+	default.set_inventory_action_loggers(def, name)
+	return def
+end
+
+if not default.set_inventory_action_loggers then
+	minetest.log("error", "[digtron] Your Minetest Game (default mod) version seems very old. Digtron may not work correctly. Please consider updating to a current version.")
+
+	digtron.set_inventory_action_loggers = function(def)
+		return def
+	end
+end
+
 -- A global dictionary is used here so that other substitutions can be added easily by other mods, if necessary
 digtron.builder_read_item_substitutions = {
 	["default:torch_ceiling"] = "default:torch",

--- a/mod.conf
+++ b/mod.conf
@@ -7,3 +7,4 @@ optional_depends = pipeworks, doc, hopper, awards, catacomb, intllib, technic
 license = MIT, LGPL 2.1 or later
 forum = https://forum.minetest.net/viewtopic.php?t=16295
 version = 0.8
+min_minetest_version = 5.5

--- a/nodes/node_battery_holder.lua
+++ b/nodes/node_battery_holder.lua
@@ -115,6 +115,4 @@ local def = {
 	after_dig_node = (function() if minetest.get_modpath("pipeworks")then return pipeworks.after_dig end end)()
 }
 
-default.set_inventory_action_loggers(def, "digtron battery holder")
-
-minetest.register_node("digtron:battery_holder", def)
+minetest.register_node("digtron:battery_holder", digtron.set_inventory_action_loggers(def))

--- a/nodes/node_controllers.lua
+++ b/nodes/node_controllers.lua
@@ -294,7 +294,7 @@ minetest.register_node("digtron:auto_controller", {
 
 			offset = offset or 0
 			local newpos = pos
-			local markerpos = {x=newpos.x, y=newpos.y, z=newpos.z}
+			local markerpos = vector.copy(newpos)
 			local x_pos = math.floor((newpos[controlling_coordinate]+offset)/slope)*slope - offset
 			markerpos[controlling_coordinate] = x_pos
 			minetest.add_entity(markerpos, "digtron:marker_vertical")

--- a/nodes/node_crate.lua
+++ b/nodes/node_crate.lua
@@ -69,7 +69,7 @@ local store_digtron = function(pos, clicker, loaded_node_name, protected)
 
 		for _, callback in ipairs(minetest.registered_on_dignodes) do
 			-- Copy pos and node because callback can modify them
-			local pos_copy = {x=old_pos.x, y=old_pos.y, z=old_pos.z}
+			local pos_copy = vector.copy(old_pos)
 			local oldnode_copy = {name=old_node.name, param1=old_node.param1, param2=old_node.param2}
 			callback(pos_copy, oldnode_copy, clicker)
 		end

--- a/nodes/node_duplicator.lua
+++ b/nodes/node_duplicator.lua
@@ -137,7 +137,7 @@ minetest.register_node("digtron:duplicator", {
 				return
 			end
 
-			layout.all[1] = {node={name=target_node.name}, meta={fields = {}, inventory = {}}, pos={x=pos.x, y=pos.y, z=pos.z}} -- replace the duplicator's image with the empty crate image
+			layout.all[1] = {node={name=target_node.name}, meta={fields = {}, inventory = {}}, pos=vector.copy(pos)} -- replace the duplicator's image with the empty crate image
 
 			-- count required nodes, skipping node 1 since it's the crate and we already know it's present in-world
 			local required_count = {}

--- a/nodes/node_storage.lua
+++ b/nodes/node_storage.lua
@@ -5,16 +5,6 @@ local S = digtron.S
 
 local pipeworks_path = minetest.get_modpath("pipeworks")
 
----Apply `default.set_inventory_action_loggers` onto the given `def` table
----@see default.set_inventory_action_loggers
----@param def table
----@param name string
----@return table def
-local function set_logger(def, name)
-	default.set_inventory_action_loggers(def, name)
-	return def
-end
-
 local inventory_formspec_string =
 	"size[8,9.3]" ..
 	default.gui_bg ..
@@ -34,7 +24,7 @@ end
 
 -- Storage buffer. Builder nodes draw from this inventory and digger nodes deposit into it.
 -- Note that inventories are digtron group 2.
-minetest.register_node("digtron:inventory", set_logger({
+minetest.register_node("digtron:inventory", digtron.set_inventory_action_loggers({
 	description = S("Digtron Inventory Storage"),
 	_doc_items_longdesc = digtron.doc.inventory_longdesc,
 	_doc_items_usagehelp = digtron.doc.inventory_usagehelp,
@@ -121,7 +111,7 @@ end
 
 -- Fuel storage. Controller node draws fuel from here.
 -- Note that fuel stores are digtron group 5.
-minetest.register_node("digtron:fuelstore", set_logger({
+minetest.register_node("digtron:fuelstore", digtron.set_inventory_action_loggers({
 	description = S("Digtron Fuel Storage"),
 	_doc_items_longdesc = digtron.doc.fuelstore_longdesc,
 	_doc_items_usagehelp = digtron.doc.fuelstore_usagehelp,
@@ -227,7 +217,7 @@ local combined_storage_formspec = function()
 end
 
 -- Combined storage. Group 6 has both an inventory and a fuel store
-minetest.register_node("digtron:combined_storage", set_logger({
+minetest.register_node("digtron:combined_storage", digtron.set_inventory_action_loggers({
 	description = S("Digtron Combined Storage"),
 	_doc_items_longdesc = digtron.doc.combined_storage_longdesc,
     _doc_items_usagehelp = digtron.doc.combined_storage_usagehelp,

--- a/util.lua
+++ b/util.lua
@@ -425,34 +425,34 @@ end
 digtron.show_offset_markers = function(pos, offset, period)
 	local buildpos = digtron.find_new_pos(pos, minetest.get_node(pos).param2)
 	local x_pos = math.floor((buildpos.x+offset)/period)*period - (offset or 0)
-	safe_add_entity({x=x_pos, y=buildpos.y, z=buildpos.z}, "digtron:marker")
+	safe_add_entity(vector.new(x_pos, buildpos.y, buildpos.z), "digtron:marker")
 	if x_pos >= buildpos.x then
-		safe_add_entity({x=x_pos - period, y=buildpos.y, z=buildpos.z}, "digtron:marker")
+		safe_add_entity(vector.new(x_pos - period, buildpos.y, buildpos.z), "digtron:marker")
 	end
 	if x_pos <= buildpos.x then
-		safe_add_entity({x=x_pos + period, y=buildpos.y, z=buildpos.z}, "digtron:marker")
+		safe_add_entity(vector.new(x_pos + period, buildpos.y, buildpos.z), "digtron:marker")
 	end
 
 	local y_pos = math.floor((buildpos.y+offset)/period)*period - offset
-	safe_add_entity({x=buildpos.x, y=y_pos, z=buildpos.z}, "digtron:marker_vertical")
+	safe_add_entity(vector.new(buildpos.x, y_pos, buildpos.z), "digtron:marker_vertical")
 	if y_pos >= buildpos.y then
-		safe_add_entity({x=buildpos.x, y=y_pos - period, z=buildpos.z}, "digtron:marker_vertical")
+		safe_add_entity(vector.new(buildpos.x, y_pos - period, buildpos.z), "digtron:marker_vertical")
 	end
 	if y_pos <= buildpos.y then
-		safe_add_entity({x=buildpos.x, y=y_pos + period, z=buildpos.z}, "digtron:marker_vertical")
+		safe_add_entity(vector.new(buildpos.x, y_pos + period, buildpos.z), "digtron:marker_vertical")
 	end
 
 	local z_pos = math.floor((buildpos.z+offset)/period)*period - offset
 
-	local entity = safe_add_entity({x=buildpos.x, y=buildpos.y, z=z_pos}, "digtron:marker")
+	local entity = safe_add_entity(vector.new(buildpos.x, buildpos.y, z_pos), "digtron:marker")
 	if entity ~= nil then entity:set_yaw(1.5708) end
 
 	if z_pos >= buildpos.z then
-		entity = safe_add_entity({x=buildpos.x, y=buildpos.y, z=z_pos - period}, "digtron:marker")
+		entity = safe_add_entity(vector.new(buildpos.x, buildpos.y, z_pos - period), "digtron:marker")
 		if entity ~= nil then entity:set_yaw(1.5708) end
 	end
 	if z_pos <= buildpos.z then
-		entity = safe_add_entity({x=buildpos.x, y=buildpos.y, z=z_pos + period}, "digtron:marker")
+		entity = safe_add_entity(vector.new(buildpos.x, buildpos.y, z_pos + period), "digtron:marker")
 		if entity ~= nil then entity:set_yaw(1.5708) end
 	end
 end

--- a/util_execute_cycle.lua
+++ b/util_execute_cycle.lua
@@ -336,7 +336,7 @@ digtron.execute_dig_cycle = function(pos, clicker)
 	if not layout:write_layout_image(clicker) then
 		return pos, "unrecoverable write_layout_image error", 1
 	end
-	local oldpos = {x=pos.x, y=pos.y, z=pos.z}
+	local oldpos = vector.copy(pos)
 	pos = vector.add(pos, dir)
 	meta = minetest.get_meta(pos)
 	if move_player then
@@ -430,7 +430,7 @@ digtron.execute_dig_cycle = function(pos, clicker)
 		end
 		-- all of the digtron's nodes wind up in nodes_dug, so this is an ideal place to stick
 		-- a check to make sand fall after the digtron has passed.
-		minetest.check_for_falling({x=node_to_dig.x, y=node_to_dig.y+1, z=node_to_dig.z})
+		minetest.check_for_falling(vector.offset(node_to_dig, 0, 1, 0))
 		node_to_dig, whether_to_dig = layout.nodes_dug:pop()
 	end
 	return pos, status_text, 0
@@ -595,7 +595,7 @@ digtron.execute_downward_dig_cycle = function(pos, clicker)
 	if not layout:write_layout_image(clicker) then
 		return pos, "unrecoverable write_layout_image error", 1
 	end
-	local oldpos = {x=pos.x, y=pos.y, z=pos.z}
+	local oldpos = vector.copy(pos)
 	pos = vector.add(pos, dir)
 	meta = minetest.get_meta(pos)
 	if move_player then


### PR DESCRIPTION
Use vector.new/copy/offset as appropriate and replace deprecated use of vector.new by vector.copy.

### Background

While doing their redstone rewrite Mineclonia decided to make aggressive use of the vector metatable and assume that it is present when positions are passed to standard callbacks (see https://codeberg.org/mineclonia/mineclonia/issues/3820). This worked out surprisingly well and it seems feasible to update mods that don't always provide the metatable. Digtron already uses vector.new in some places and this PR consistently replaces all manually created position vectors with the appropriate vector constructor.

### Testing

There should be no change in digtron behavior.